### PR TITLE
Update asyncapi-react to 1.0.0-next.21

### DIFF
--- a/asynction/templates/index.html.j2
+++ b/asynction/templates/index.html.j2
@@ -7,14 +7,14 @@
     <title>{{ info.title }} {{ info.version }} – Asynction Docs</title>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@asyncapi/react-component@1.0.0-next.18/styles/default.min.css"
+      href="https://unpkg.com/@asyncapi/react-component@1.0.0-next.21/styles/default.min.css"
       integriry="sha384-JD4WiisNFV+VyC+uSfnk/c4cpj/cbbFsHTp10LWs5DamvZfOzcV1xaaURK7SAknk"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     >
     <script
-      src="https://unpkg.com/@asyncapi/react-component@1.0.0-next.18/browser/standalone/index.js"
-      integriry="sha384-ZDyBf52lSGWGgpA8NKTsHueZMyrUEjVrqzNHpQtVxJdEgsCMRbmDijrmo2L2S671"
+      src="https://unpkg.com/@asyncapi/react-component@1.0.0-next.21/browser/standalone/index.js"
+      integriry="sha384-MfJHIcfQj/tW4U1JEGkFy68RQ9ABfqmLMESCyzT//4XzGTO/tdAvqEyB5qz98spD"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>


### PR DESCRIPTION
In reference to #109 

Update asyncapi-react to 1.0.0-next.21
Update script integrity hashes.

NOTE: The hash for https://unpkg.com/@asyncapi/react-component@1.0.0-next.18/styles/default.min.css
was the same as the hash for https://unpkg.com/@asyncapi/react-component@1.0.0-next.21/styles/default.min.css
Which means that the file did not change, not that the hash was not recomputed