### PR TITLE
Allow pre loaded AsyncAPISpec in from_spec

### DIFF
--- a/asynction/mock_server.py
+++ b/asynction/mock_server.py
@@ -162,7 +162,7 @@ class MockAsynctionSocketIO(AsynctionSocketIO):
         * ``custom_formats_sample_size``
 
         :param spec_path: The path where the AsyncAPI YAML specification is located,
-                     or a pre loaded AsyncApiSpec object.
+                          or a pre loaded AsyncApiSpec object.
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.

--- a/asynction/mock_server.py
+++ b/asynction/mock_server.py
@@ -139,7 +139,7 @@ class MockAsynctionSocketIO(AsynctionSocketIO):
     @classmethod
     def from_spec(
         cls,
-        spec_path: Union[Path, AsyncApiSpec],
+        spec_path: Union[Path, JSONMapping],
         validation: bool = True,
         server_name: Optional[str] = None,
         docs: bool = True,
@@ -162,7 +162,7 @@ class MockAsynctionSocketIO(AsynctionSocketIO):
         * ``custom_formats_sample_size``
 
         :param spec_path: The path where the AsyncAPI YAML specification is located,
-                          or a pre loaded AsyncApiSpec object.
+                          or a pre loaded JSONMapping object.
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.

--- a/asynction/mock_server.py
+++ b/asynction/mock_server.py
@@ -17,6 +17,7 @@ from typing import Mapping
 from typing import MutableSequence
 from typing import Optional
 from typing import Sequence
+from typing import Union
 
 from faker import Faker
 from faker.exceptions import UnsupportedFeature
@@ -138,7 +139,7 @@ class MockAsynctionSocketIO(AsynctionSocketIO):
     @classmethod
     def from_spec(
         cls,
-        spec_path: Path,
+        spec_path: Union[Path, AsyncApiSpec],
         validation: bool = True,
         server_name: Optional[str] = None,
         docs: bool = True,
@@ -160,7 +161,8 @@ class MockAsynctionSocketIO(AsynctionSocketIO):
 
         * ``custom_formats_sample_size``
 
-        :param spec_path: The path where the AsyncAPI YAML specification is located.
+        :param spec_path: The path where the AsyncAPI YAML specification is located,
+                     or a pre loaded AsyncApiSpec object.
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.

--- a/asynction/mock_server.py
+++ b/asynction/mock_server.py
@@ -162,7 +162,7 @@ class MockAsynctionSocketIO(AsynctionSocketIO):
         * ``custom_formats_sample_size``
 
         :param spec_path: The path where the AsyncAPI YAML specification is located,
-                          or a pre loaded JSONMapping object.
+                          or a dictionary object of the AsyncAPI data structure
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.

--- a/asynction/server.py
+++ b/asynction/server.py
@@ -114,7 +114,7 @@ class AsynctionSocketIO(SocketIO):
     @classmethod
     def from_spec(
         cls,
-        spec_path: Union[Path, AsyncApiSpec],
+        spec_path: Union[Path, JSONMapping],
         validation: bool = True,
         server_name: Optional[str] = None,
         docs: bool = True,
@@ -126,7 +126,7 @@ class AsynctionSocketIO(SocketIO):
         This is the single entrypoint to the Asynction server API.
 
         :param spec_path: The path where the AsyncAPI YAML specification is located,
-                          or a pre loaded AsyncApiSpec object.
+                          or a pre loaded JSONMapping object.
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.
@@ -157,10 +157,11 @@ class AsynctionSocketIO(SocketIO):
             )
 
         """
-        if isinstance(spec_path, AsyncApiSpec):
-            spec = spec_path
-        else:
+        if isinstance(spec_path, Path):
             spec = load_spec(spec_path=spec_path)
+        else:
+            raw_resolved = resolve_references(raw_spec=spec_path)
+            spec = AsyncApiSpec.from_dict(raw_resolved)
 
         server_security: Sequence[SecurityRequirement] = []
         if (

--- a/asynction/server.py
+++ b/asynction/server.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from typing import Optional
 from typing import Sequence
+from typing import Union
 from urllib.parse import urlparse
 
 import jsonschema
@@ -113,7 +114,7 @@ class AsynctionSocketIO(SocketIO):
     @classmethod
     def from_spec(
         cls,
-        spec_path: Path,
+        spec_path: Union[Path, AsyncApiSpec],
         validation: bool = True,
         server_name: Optional[str] = None,
         docs: bool = True,
@@ -124,7 +125,8 @@ class AsynctionSocketIO(SocketIO):
         """Create a Flask-SocketIO server from an AsyncAPI spec.
         This is the single entrypoint to the Asynction server API.
 
-        :param spec_path: The path where the AsyncAPI YAML specification is located.
+        :param spec_path: The path where the AsyncAPI YAML specification is located,
+                     or a pre loaded AsyncApiSpec object.
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.
@@ -155,7 +157,11 @@ class AsynctionSocketIO(SocketIO):
             )
 
         """
-        spec = load_spec(spec_path=spec_path)
+        if isinstance(spec_path, AsyncApiSpec):
+            spec = spec_path
+        else:
+            spec = load_spec(spec_path=spec_path)
+
         server_security: Sequence[SecurityRequirement] = []
         if (
             server_name is not None

--- a/asynction/server.py
+++ b/asynction/server.py
@@ -68,13 +68,15 @@ def resolve_references(raw_spec: JSONMapping) -> JSONMapping:
     return deep_resolve(raw_spec, resolver)
 
 
-def load_spec(spec_path: Path) -> AsyncApiSpec:
-    with open(spec_path) as f:
-        serialized = f.read()
-        raw = yaml.safe_load(serialized)
+def load_spec(spec_path: Union[Path, JSONMapping]) -> AsyncApiSpec:
+    if isinstance(spec_path, Path):
+        with open(spec_path) as f:
+            serialized = f.read()
+            spec = yaml.safe_load(serialized)
+    else:
+        spec = spec_path
 
-    raw_resolved = resolve_references(raw_spec=raw)
-
+    raw_resolved = resolve_references(spec)
     return AsyncApiSpec.from_dict(raw_resolved)
 
 
@@ -126,7 +128,7 @@ class AsynctionSocketIO(SocketIO):
         This is the single entrypoint to the Asynction server API.
 
         :param spec_path: The path where the AsyncAPI YAML specification is located,
-                          or a pre loaded JSONMapping object.
+                          or a dictionary object of the AsyncAPI data structure
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.
@@ -157,11 +159,7 @@ class AsynctionSocketIO(SocketIO):
             )
 
         """
-        if isinstance(spec_path, Path):
-            spec = load_spec(spec_path=spec_path)
-        else:
-            raw_resolved = resolve_references(raw_spec=spec_path)
-            spec = AsyncApiSpec.from_dict(raw_resolved)
+        spec = load_spec(spec_path=spec_path)
 
         server_security: Sequence[SecurityRequirement] = []
         if (

--- a/asynction/server.py
+++ b/asynction/server.py
@@ -126,7 +126,7 @@ class AsynctionSocketIO(SocketIO):
         This is the single entrypoint to the Asynction server API.
 
         :param spec_path: The path where the AsyncAPI YAML specification is located,
-                     or a pre loaded AsyncApiSpec object.
+                          or a pre loaded AsyncApiSpec object.
         :param validation: When set to ``False``, message payloads, channel
                            bindings and ack callbacks are NOT validated.
                            Defaults to ``True``.

--- a/tests/unit/test_mock_server.py
+++ b/tests/unit/test_mock_server.py
@@ -29,6 +29,7 @@ from asynction.mock_server import task_runner
 from asynction.mock_server import task_scheduler
 from asynction.server import AsynctionSocketIO
 from asynction.server import _noop_handler
+from asynction.server import load_spec
 from asynction.types import GLOBAL_NAMESPACE
 from asynction.types import AsyncApiSpec
 from asynction.types import Channel
@@ -136,6 +137,13 @@ def test_generate_fake_data_from_schema_using_custom_formats(faker: Faker):
 
 def test_mock_asynction_socketio_from_spec(fixture_paths: FixturePaths):
     mock_asio = MockAsynctionSocketIO.from_spec(spec_path=fixture_paths.simple)
+    assert isinstance(mock_asio, MockAsynctionSocketIO)
+    assert isinstance(mock_asio.faker, Faker)
+
+
+def test_mock_asynction_socketio_from_spec_object(fixture_paths: FixturePaths):
+    spec = load_spec(fixture_paths.simple)
+    mock_asio = MockAsynctionSocketIO.from_spec(spec_path=spec)
     assert isinstance(mock_asio, MockAsynctionSocketIO)
     assert isinstance(mock_asio.faker, Faker)
 

--- a/tests/unit/test_mock_server.py
+++ b/tests/unit/test_mock_server.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 import jsonschema
 import pytest
+import yaml
 from faker import Faker
 from flask.app import Flask
 from flask_socketio import SocketIO
@@ -29,7 +30,6 @@ from asynction.mock_server import task_runner
 from asynction.mock_server import task_scheduler
 from asynction.server import AsynctionSocketIO
 from asynction.server import _noop_handler
-from asynction.server import load_spec
 from asynction.types import GLOBAL_NAMESPACE
 from asynction.types import AsyncApiSpec
 from asynction.types import Channel
@@ -142,7 +142,8 @@ def test_mock_asynction_socketio_from_spec(fixture_paths: FixturePaths):
 
 
 def test_mock_asynction_socketio_from_spec_object(fixture_paths: FixturePaths):
-    spec = load_spec(fixture_paths.simple)
+    with open(fixture_paths.simple, "r") as simple:
+        spec = yaml.safe_load(simple)
     mock_asio = MockAsynctionSocketIO.from_spec(spec_path=spec)
     assert isinstance(mock_asio, MockAsynctionSocketIO)
     assert isinstance(mock_asio.faker, Faker)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,6 +2,7 @@ from typing import Optional
 from unittest import mock
 
 import pytest
+import yaml
 from faker import Faker
 from flask import Flask
 
@@ -51,7 +52,8 @@ def test_asynction_socketio_from_spec(fixture_paths: FixturePaths):
 
 
 def test_asynction_socketio_from_spec_object(fixture_paths: FixturePaths):
-    spec = load_spec(fixture_paths.simple)
+    with open(fixture_paths.simple, "r") as simple:
+        spec = yaml.safe_load(simple)
     asio = AsynctionSocketIO.from_spec(spec_path=spec)
     assert isinstance(asio, AsynctionSocketIO)
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -50,6 +50,12 @@ def test_asynction_socketio_from_spec(fixture_paths: FixturePaths):
     assert isinstance(asio, AsynctionSocketIO)
 
 
+def test_asynction_socketio_from_spec_object(fixture_paths: FixturePaths):
+    spec = load_spec(fixture_paths.simple)
+    asio = AsynctionSocketIO.from_spec(spec_path=spec)
+    assert isinstance(asio, AsynctionSocketIO)
+
+
 def test_asynction_socketio_from_spec_uses_spec_server_path_as_socketio_path(
     fixture_paths: FixturePaths,
 ):


### PR DESCRIPTION
Allow `from_spec` to accept an `AsyncApiSpec` object or the `Path` to an asyncapi file.
This will aid in the implementation of spec merging from #108 by allowing the programmer to load and merge specs and then pass in the merged spec rather than having to write the merged spec back out to file.